### PR TITLE
Fixing input-chunk matching and adding functionality to return more than 1 chunk

### DIFF
--- a/app/find_matches.py
+++ b/app/find_matches.py
@@ -2,8 +2,8 @@ from utils.db import find_best_match
 from utils.embedding import embed_text
 from utils.db import get_connection
 
-def find_matches(text):
+def find_matches(text, n=1):
     conn = get_connection()
     embedded = embed_text(text)
-    result = find_best_match(conn, embedded)
+    result = find_best_match(conn, embedded, n)
     return result

--- a/app/main.py
+++ b/app/main.py
@@ -18,10 +18,12 @@ def main():
     
     embed_articles()       # Go through the json, embed chunks and insert into db
     
-    input_text = "One could mix up helsingfors and helsingborg, ending up in an old swedish city instead of a finnish one"
-    result = find_matches(input_text)
-    print(f"Here's the top result:") 
-    print(f"Article name: {result[3]} \n\n Content: {result[1]}")
+    input_text = "Helsinki (Helsingfors in Swedish) is the current capital of Finland, and it should not be confused with the Swedish city of Helsingborg, which is a city in south-western Sweden. Helsingborg, in fact, is closer to Denmark than Finland. Before Helsinki became capital, Turku was the capital of Finland, until it burned down."
+    result = find_matches(input_text, 4) # Number of matches is optional, default=1
+    print(f"Here are the top {len(result)} result(s):")
+    for i, chunk in enumerate(result):
+        print(f"Chunk {i + 1} (from article '{chunk[3]}'): {chunk[1]}")
+    # print(f"Article name: {result[3]} \n\n Content: {result[1]}")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Fixing input-chunk matching:
- Changing vector comparison method from Euclidean Distance to Cosine Similarity
- Changing the format of the input vector passed to the SQL query

Adding functionality to return more than 1 chunk:
- The k nearest chunks (with k being set by the user, default value 1), can now be returned, instead of just 1